### PR TITLE
Change get_train_sampler to handle input dataset

### DIFF
--- a/tina/post_train_hf/grpo_trainer.py
+++ b/tina/post_train_hf/grpo_trainer.py
@@ -461,12 +461,10 @@ class GRPOTrainer(Trainer):
         if self._signature_columns is None:
             self._signature_columns = ["prompt"]
 
-    def _get_train_sampler(self) -> Sampler:
-        # Returns a sampler that ensures each prompt is repeated across multiple processes. This guarantees that
-        # identical prompts are distributed to different GPUs, allowing rewards to be computed and normalized correctly
-        # within each prompt group. Using the same seed across processes ensures consistent prompt assignment,
-        # preventing discrepancies in group formation.
-        return RepeatRandomSampler(self.train_dataset, self.num_generations, seed=self.args.seed)
+    def _get_train_sampler(self, train_dataset=None) -> Sampler:
+        if train_dataset is None:
+            train_dataset = self.train_dataset
+        return RepeatRandomSampler(train_dataset, self.num_generations, seed=self.args.seed)
 
     def _get_eval_sampler(self, eval_dataset) -> Sampler:
         # Returns a sampler that ensures each prompt is repeated across multiple processes. This guarantees that


### PR DESCRIPTION
Addresses #4 

I think the newest transformer package changed the function signature of the sampler function to include the desired dataset. This seems to work correctly now, when running the training script `./scripts/training/post_train_grpo.sh`